### PR TITLE
Fix missing colors variable in Transaction_Review.py

### DIFF
--- a/streamlit_app/pages/Transaction_Review.py
+++ b/streamlit_app/pages/Transaction_Review.py
@@ -18,6 +18,7 @@ import json
 from typing import Dict, Any, List
 
 from streamlit_app.api_client import get_api_client
+from streamlit_app.theme import get_chart_colors
 
 
 def render_workflow_diagram():
@@ -910,6 +911,9 @@ def render():
     """Main render function for Transaction Review Detail page"""
 
     st.set_page_config(page_title="Transaction Review Detail", page_icon="🔍", layout="wide")
+
+    # Get standardized chart colors
+    colors = get_chart_colors()
 
     # Header with blue theme
     st.markdown("""


### PR DESCRIPTION
Added missing import and call to get_chart_colors() which is used throughout the page for chart styling. This fixes the NameError that was preventing the page from rendering.